### PR TITLE
SUPP: update pymapd version >= 0.20.0

### DIFF
--- a/ci_requirements.yml
+++ b/ci_requirements.yml
@@ -8,7 +8,7 @@ dependencies:
   - mysql-connector-python
   - numpy>=1.11
   - pandas>=1.0.0
-  - pymapd>=0.12.0
+  - pymapd>=0.20.0
   - xgboost
   - daal4py
   - scikit-learn


### PR DESCRIPTION
One of synthetic benchmarks start failed after omnisci bumped pymapd version >= 0.20.0

I think we should do the same.

Omnisci commit hash with the change: 6ca47d0f6437061a560dc54215569af9c26ee215

