### PR TITLE
Correction to run CI on the OmniSciDB master

### DIFF
--- a/run_ibis_tests.py
+++ b/run_ibis_tests.py
@@ -203,7 +203,6 @@ try:
                                    '-db-table',
                                    args.db_table if args.db_table else 'santander',
                                    '-val',
-                                   '--enable-columnar-output',
                                    '-commit_omnisci', args.commit_omnisci,
                                    '-commit_ibis', args.commit_ibis]
 

--- a/server/server.py
+++ b/server/server.py
@@ -28,7 +28,7 @@ class OmnisciServer:
         max_session_duration=86400,
         idle_session_duration=120,
         debug_timer=False,
-        columnar_output=True,
+        columnar_output=None,
         lazy_fetch=None,
     ):  # default values of max_session_duration=43200 idle_session_duration=60
         self.omnisci_executable = omnisci_executable


### PR DESCRIPTION
Current OmniSciDB master doesn't know --enable-columnar flag